### PR TITLE
Rework the CLI error type

### DIFF
--- a/src/Confer/CLI/Cmd/Check.hs
+++ b/src/Confer/CLI/Cmd/Check.hs
@@ -15,7 +15,7 @@ import Effectful.Error.Static qualified as Error
 import GHC.Float
 import Validation
 
-import Confer.CLI.Errors (CLIError (..))
+import Confer.CLI.Errors
 import Confer.CLI.UI
 import Confer.Config.Types
 import Confer.Effect.Symlink (Symlink, SymlinkError (..))
@@ -23,7 +23,7 @@ import Confer.Effect.Symlink qualified as Symlink
 
 check
   :: ( Symlink :> es
-     , Error CLIError :> es
+     , Error (NonEmpty CLIError) :> es
      , Console :> es
      , Concurrent :> es
      )
@@ -41,7 +41,7 @@ check quiet deployments = do
         validateSymlink fact
   case result of
     Failure errors -> do
-      Error.throwError (SymlinkErrors errors)
+      Error.throwError (toCliError <$> errors)
     Success _ ->
       unless quiet $ printProgress "Checking links" 1.0
 

--- a/src/Confer/CLI/Cmd/Deploy.hs
+++ b/src/Confer/CLI/Cmd/Deploy.hs
@@ -2,6 +2,7 @@ module Confer.CLI.Cmd.Deploy (deploy) where
 
 import Control.Monad
 
+import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Text.Display
 import Data.Text.IO qualified as Text
@@ -15,7 +16,7 @@ import System.OsPath qualified as OsPath
 
 import Confer.CLI.Errors
 import Confer.Config.Types
-import Confer.Effect.Symlink (Symlink)
+import Confer.Effect.Symlink (Symlink, SymlinkError (..))
 import Confer.Effect.Symlink qualified as Symlink
 
 -- | Take a filtered and checked list of deployments.
@@ -30,7 +31,7 @@ deploy
   :: ( FileSystem :> es
      , Symlink :> es
      , IOE :> es
-     , Error CLIError :> es
+     , Error (NonEmpty CLIError) :> es
      )
   => Bool
   -> Vector Deployment
@@ -44,8 +45,13 @@ deploy quiet deployments = do
         then do
           result <- Symlink.testSymlink fact.destination fact.source
           case result of
-            Left err ->
-              throwError $ SymlinkErrors (NE.singleton err)
+            Left symlinkError -> do
+              let cliError = case symlinkError of
+                    DoesNotExist path -> symlinkDoesNotExistError path
+                    IsNotSymlink path -> pathIsNotSymlinkError path
+                    AlreadyExists path -> symlinkAlreadyExistsError path
+                    WrongTarget link expected actual -> wrongTargetError link expected actual
+              throwError (NE.singleton cliError)
             Right _ ->
               liftIO $ Text.putStrLn $ display (linkFilepath <> " ✅")
         else do

--- a/src/Confer/Effect/Symlink.hs
+++ b/src/Confer/Effect/Symlink.hs
@@ -41,7 +41,7 @@ data SymlinkError
       -- ^ Expected target
       OsPath
       -- ^ Actual target
-  deriving stock (Show, Eq)
+  deriving stock (Show, Ord, Eq)
 
 data Symlink :: Effect where
   CreateSymlink :: OsPath -> OsPath -> Symlink m ()


### PR DESCRIPTION
`CLIError` is now a type that holds the error code and the message of the error, and a sum type member from `CLIErrorType`.